### PR TITLE
Fix comment typo in Binance websocket hook

### DIFF
--- a/src/hooks/useBinanceWebSocket.ts
+++ b/src/hooks/useBinanceWebSocket.ts
@@ -17,7 +17,7 @@ export interface TradeData { // Exporting for PriceChart
   t: number; // Trade ID
   p: string; // Price
   q: string; // Quantity
-  m: boolean; // Is the buyer the Bmaker?
+  m: boolean; // Is the buyer the maker?
   // Other fields like 'b' (buyer order ID), 'a' (seller order ID) exist but might not be needed for chart
 }
 


### PR DESCRIPTION
## Summary
- fix comment in `useBinanceWebSocket.ts` that asks if the buyer is the maker

## Testing
- `npm run lint` *(fails: `'e' is defined but never used`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68427e3fd8c8832fa6505f30b57a7eb2