### PR TITLE
Fix order fill timer cleanup

### DIFF
--- a/src/context/OrderContext.tsx
+++ b/src/context/OrderContext.tsx
@@ -1,6 +1,14 @@
 // src/context/OrderContext.tsx
 'use client';
-import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useCallback,
+  useRef,
+  useEffect,
+} from 'react';
 
 // Define the structure of an order/trade
 export interface Order {
@@ -35,6 +43,7 @@ export const OrderProvider: React.FC<OrderProviderProps> = ({ children }) => {
   const [openOrders, setOpenOrders] = useState<Order[]>([]);
   const [tradeHistory, setTradeHistory] = useState<Order[]>([]);
   const [orderIdCounter, setOrderIdCounter] = useState(1);
+  const fillTimer = useRef<NodeJS.Timeout | null>(null);
 
   const placeOrder = useCallback((newOrderData: Omit<Order, 'id' | 'time'>) => {
     const newOrder: Order = {
@@ -47,12 +56,20 @@ export const OrderProvider: React.FC<OrderProviderProps> = ({ children }) => {
     setOpenOrders(prev => [newOrder, ...prev]);
 
     // Simulate order fill after a delay (e.g., 3-5 seconds)
-    setTimeout(() => {
+    fillTimer.current = setTimeout(() => {
       setOpenOrders(prev => prev.filter(o => o.id !== newOrder.id));
       setTradeHistory(prev => [{...newOrder, type: 'Limit'}, ...prev]); // Assume it filled as a limit order for history
     }, 3000 + Math.random() * 2000);
 
   }, [orderIdCounter]);
+
+  useEffect(() => {
+    return () => {
+      if (fillTimer.current) {
+        clearTimeout(fillTimer.current);
+      }
+    };
+  }, []);
 
   const cancelOrder = useCallback((orderId: number) => {
     setOpenOrders(prev => prev.filter(o => o.id !== orderId));


### PR DESCRIPTION
## Summary
- manage timeout with a ref
- clear timer on unmount to avoid lingering callbacks

## Testing
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68427f12e654832fb2c4440dd2340ded